### PR TITLE
Add table overflow scrolling [issue 2]

### DIFF
--- a/public/javascripts/grades.js
+++ b/public/javascripts/grades.js
@@ -40,7 +40,10 @@ function makePlots() {
             var columns = getTableColumns(chosenElement);
             setOptions(columns, assignmentSelector);
 
-            var table = d3.select("#grdTable"),
+            var table = d3.select("#grdTable")
+			.style('display', 'block')
+			.style('overflow-x', 'auto')
+			.style('white-space', 'nowrap'),
                 thead = table.append("thead"),
                 tbody = table.append("tbody");
 


### PR DESCRIPTION
This change fixes #2 by adding CSS styling to the D3 table to enable overflow scrolling. 